### PR TITLE
bugfix/import_error

### DIFF
--- a/tfpipe/__init__.py
+++ b/tfpipe/__init__.py
@@ -9,7 +9,6 @@ import tfpipe.modules.blast
 import tfpipe.modules.plink
 import tfpipe.modules.qiime
 import tfpipe.modules.bowtie
-import tfpipe.modules.galaxy
 import tfpipe.modules.picard
 import tfpipe.modules.tophat
 import tfpipe.modules.dfilter


### PR DESCRIPTION
Removed an import for the galaxy module from the **init**.py file, which was causing the pipeline to fail.
